### PR TITLE
Deny vnet peerings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,12 +34,7 @@ jobs:
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_JSON: true
-          VALIDATE_MARKDOWN: true
-          VALIDATE_POWERSHELL: true
-          VALIDATE_YAML: true
           YAMLLINT_CONFIG_FILE: .github/workflows/lint.yml
-          VALIDATE_EDITORCONFIG: true
 
       - name: Lint Bicep Files
         shell: pwsh

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,8 @@
         "ondfisk",
         "ondfisklz",
         "ondfisklzcanary",
+        "peerings",
+        "vnet",
         "RAGRS",
         "GZRS",
         "RAGZRS",

--- a/environments/canary/vars.yml
+++ b/environments/canary/vars.yml
@@ -4,6 +4,6 @@ variables:
   vmImage: ubuntu-latest
   managementGroupId: lz-canary
   location: swedencentral
-  policyAssignmentFolders: lz-canary, lz-canary/landing-zones/corp
+  policyAssignmentFolders: lz-canary, lz-canary/landing-zones/corp, lz-canary/landing-zones/online
   managedIdentityId: /subscriptions/8228ddb9-d118-47b4-b4e7-1f1de7667d4d/resourceGroups/Management/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ondfisklzcanary
   logAnalyticsWorkspaceId: /subscriptions/8228ddb9-d118-47b4-b4e7-1f1de7667d4d/resourceGroups/Management/providers/Microsoft.OperationalInsights/workspaces/ondfisklzcanary

--- a/environments/prod/vars.yml
+++ b/environments/prod/vars.yml
@@ -4,6 +4,6 @@ variables:
   vmImage: ubuntu-latest
   managementGroupId: lz
   location: swedencentral
-  policyAssignmentFolders: lz, lz/landing-zones/corp
+  policyAssignmentFolders: lz, lz/landing-zones/corp, lz/landing-zones/online
   managedIdentityId: /subscriptions/e678d35b-125e-41ad-ae35-c04dfd4162e5/resourceGroups/Management/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ondfisklz
   logAnalyticsWorkspaceId: /subscriptions/e678d35b-125e-41ad-ae35-c04dfd4162e5/resourceGroups/Management/providers/Microsoft.OperationalInsights/workspaces/ondfisklz

--- a/modules/policies/assignments/app-service-config.bicep
+++ b/modules/policies/assignments/app-service-config.bicep
@@ -8,7 +8,7 @@ module App_Service_Config '../../shared/policy-assignment.bicep' = {
   params: {
     location: location
     policyAssignmentName: 'app-service-config'
-    policyDefinitionId: extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policySetDefinitions', 'configure-app-service-security')
+    policyDefinitionId: managementGroupResourceId('Microsoft.Authorization/policySetDefinitions', 'configure-app-service-security')
     userAssignedIdentity: managedIdentityId
     parameters: {}
   }

--- a/modules/policies/assignments/defender-for-cloud.bicep
+++ b/modules/policies/assignments/defender-for-cloud.bicep
@@ -9,7 +9,7 @@ module Defender_For_Cloud '../../shared/policy-assignment.bicep' = {
   params: {
     location: location
     policyAssignmentName: 'defender-for-cloud'
-    policyDefinitionId: extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policySetDefinitions', 'configure-defender-for-cloud')
+    policyDefinitionId: managementGroupResourceId('Microsoft.Authorization/policySetDefinitions', 'configure-defender-for-cloud')
     userAssignedIdentity: managedIdentityId
     parameters: {
       logAnalytics: {

--- a/modules/policies/assignments/diagnostic-config.bicep
+++ b/modules/policies/assignments/diagnostic-config.bicep
@@ -9,7 +9,7 @@ module Diagnostic_Config '../../shared/policy-assignment.bicep' = {
   params: {
     location: location
     policyAssignmentName: 'diagnostic-config'
-    policyDefinitionId: extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policySetDefinitions', 'configure-diagnostic-settings')
+    policyDefinitionId: managementGroupResourceId('Microsoft.Authorization/policySetDefinitions', 'configure-diagnostic-settings')
     userAssignedIdentity: managedIdentityId
     parameters: {
       logAnalytics: {

--- a/modules/policies/assignments/function-app-config.bicep
+++ b/modules/policies/assignments/function-app-config.bicep
@@ -8,7 +8,7 @@ module Function_App_Config '../../shared/policy-assignment.bicep' = {
   params: {
     location: location
     policyAssignmentName: 'function-app-config'
-    policyDefinitionId: extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policySetDefinitions', 'configure-function-app-security')
+    policyDefinitionId: managementGroupResourceId('Microsoft.Authorization/policySetDefinitions', 'configure-function-app-security')
     userAssignedIdentity: managedIdentityId
     parameters: {}
   }

--- a/modules/policies/assignments/key-vault-config.bicep
+++ b/modules/policies/assignments/key-vault-config.bicep
@@ -8,7 +8,7 @@ module Key_Vault_Config '../../shared/policy-assignment.bicep' = {
   params: {
     location: location
     policyAssignmentName: 'key-vault-config'
-    policyDefinitionId: extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policySetDefinitions', 'configure-key-vault-security')
+    policyDefinitionId: managementGroupResourceId('Microsoft.Authorization/policySetDefinitions', 'configure-key-vault-security')
     userAssignedIdentity: managedIdentityId
     parameters: {}
   }

--- a/modules/policies/assignments/landing-zones/online/vnet-deny-peering.bicep
+++ b/modules/policies/assignments/landing-zones/online/vnet-deny-peering.bicep
@@ -2,7 +2,7 @@ targetScope = 'managementGroup'
 
 param location string = deployment().location
 
-module Nic_Deny_Public_IP '../../../../shared/policy-assignment.bicep' = {
+module VNET_Deny_Peering '../../../../shared/policy-assignment.bicep' = {
   name: 'vnet-deny-peering-assignment'
   params: {
     location: location

--- a/modules/policies/assignments/landing-zones/online/vnet-deny-peering.bicep
+++ b/modules/policies/assignments/landing-zones/online/vnet-deny-peering.bicep
@@ -8,7 +8,7 @@ module VNET_Deny_Peering '../../../../shared/policy-assignment.bicep' = {
   params: {
     location: location
     policyAssignmentName: 'vnet-deny-peering'
-    policyDefinitionId: extensionResourceId(managementGroupId, 'Microsoft.Authorization/policyDefinitions', 'vnet-deny-peering')
+    policyDefinitionId: managementGroupResourceId(managementGroupId, 'Microsoft.Authorization/policyDefinitions', 'vnet-deny-peering')
     parameters: {}
   }
 }

--- a/modules/policies/assignments/landing-zones/online/vnet-deny-peering.bicep
+++ b/modules/policies/assignments/landing-zones/online/vnet-deny-peering.bicep
@@ -1,0 +1,13 @@
+targetScope = 'managementGroup'
+
+param location string = deployment().location
+
+module Nic_Deny_Public_IP '../../../../shared/policy-assignment.bicep' = {
+  name: 'vnet-deny-peering-assignment'
+  params: {
+    location: location
+    policyAssignmentName: 'vnet-deny-peering'
+    policyDefinitionId: extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policyDefinitions', 'vnet-deny-peering')
+    parameters: {}
+  }
+}

--- a/modules/policies/assignments/landing-zones/online/vnet-deny-peering.bicep
+++ b/modules/policies/assignments/landing-zones/online/vnet-deny-peering.bicep
@@ -1,13 +1,14 @@
 targetScope = 'managementGroup'
 
 param location string = deployment().location
+param managementGroupId string
 
 module VNET_Deny_Peering '../../../../shared/policy-assignment.bicep' = {
   name: 'vnet-deny-peering-assignment'
   params: {
     location: location
     policyAssignmentName: 'vnet-deny-peering'
-    policyDefinitionId: extensionResourceId(managementGroup().id, 'Microsoft.Authorization/policyDefinitions', 'vnet-deny-peering')
+    policyDefinitionId: extensionResourceId(managementGroupId, 'Microsoft.Authorization/policyDefinitions', 'vnet-deny-peering')
     parameters: {}
   }
 }

--- a/modules/policies/policies/vnet-deny-peering.json
+++ b/modules/policies/policies/vnet-deny-peering.json
@@ -24,8 +24,20 @@
     },
     "policyRule": {
       "if": {
-        "equals": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
-        "field": "type"
+        "allOf": [
+          {
+            "field": "type",
+            "equals": "Microsoft.Network/virtualNetworks"
+          },
+          {
+            "field": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+            "exists": "true"
+          },
+          {
+            "value": "[length(field('Microsoft.Network/virtualNetworks/virtualNetworkPeerings'))]",
+            "greater": 0
+          }
+        ]
       },
       "then": {
         "effect": "[parameters('effect')]"

--- a/modules/policies/policies/vnet-deny-peering.json
+++ b/modules/policies/policies/vnet-deny-peering.json
@@ -1,0 +1,37 @@
+{
+  "properties": {
+    "displayName": "Virtual networks should not have peerings",
+    "mode": "Indexed",
+    "description": "This policy denies virtual network peerings.",
+    "metadata": {
+      "version": "1.0",
+      "category": "Network"
+    },
+    "parameters": {
+      "effect": {
+        "type": "String",
+        "metadata": {
+          "displayName": "Effect",
+          "description": "Enable or disable the execution of the policy"
+        },
+        "allowedValues": [
+          "Deny",
+          "Audit",
+          "Disabled"
+        ],
+        "defaultValue": "Deny"
+      }
+    },
+    "policyRule": {
+      "if": {
+        "equals": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+        "field": "type"
+      },
+      "then": {
+        "effect": "[parameters('effect')]"
+      }
+    }
+  },
+  "type": "Microsoft.Authorization/policyDefinitions",
+  "name": "vnet-deny-peering"
+}


### PR DESCRIPTION
This pull request includes changes to the linting configuration, Visual Studio Code settings, environment variables, and policy assignments in the codebase. The most significant changes involve the addition of new policy assignments and the modification of existing ones. Additionally, the linting configuration has been simplified, and new terms have been added to the Visual Studio Code settings. The environment variables have also been updated to include new policy assignment folders.

Linting configuration:

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L37-L42): Removed several environment variables related to validation, simplifying the linting process.

Visual Studio Code settings:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R30-R31): Added "peerings" and "vnet" to the list of terms.

Environment variables:

* `environments/canary/vars.yml` and `environments/prod/vars.yml`: Added "lz-canary/landing-zones/online" and "lz/landing-zones/online" respectively to the `policyAssignmentFolders` variable. [[1]](diffhunk://#diff-a139ab513f9c5a9d57a906e827639f4202acd645f918120bfe0582020a552804L7-R7) [[2]](diffhunk://#diff-105173c98b6c0a7d029ddb9aadf595cd8104182196c70318d304e9f83a28f350L7-R7)

Policy assignments:

* `modules/policies/assignments/app-service-config.bicep`, `modules/policies/assignments/defender-for-cloud.bicep`, `modules/policies/assignments/diagnostic-config.bicep`, `modules/policies/assignments/function-app-config.bicep`, `modules/policies/assignments/key-vault-config.bicep`: Changed the `policyDefinitionId` to use `managementGroupResourceId` instead of `extensionResourceId`. [[1]](diffhunk://#diff-14a9b721de2e126bedbc1975dd14bb589c96d954b3501e3dc1de8ee52596bd72L11-R11) [[2]](diffhunk://#diff-a8e8ba064dd2bc3290ef5df8d8a4960b220d096d200b1746b98f0f35d65df734L12-R12) [[3]](diffhunk://#diff-5e82fb0d4d3d9289973066fe55fad7ba31170c1eeb8a14b138bc95aa4ea79044L12-R12) [[4]](diffhunk://#diff-1c2d7c383b2bcef66efc8f31b510d89c9a2109a5db001ef54dd14db5582ef496L11-R11) [[5]](diffhunk://#diff-c6554822c36e6d1d1d9bffbc0541c88cedbd0f8de65ada49b0f459667c08af47L11-R11)
* [`modules/policies/assignments/landing-zones/online/vnet-deny-peering.bicep`](diffhunk://#diff-597ea99c8847f89b16e1ac085348529f96f16871c07f861f0cf8b75366e964a6R1-R14): Added a new policy assignment module for denying virtual network peerings.
* [`modules/policies/policies/vnet-deny-peering.json`](diffhunk://#diff-e62de0dce64bcd2bc9d11b4fbc1c692da84079457e027d576a0e597f7303b20eR1-R49): Added a new policy definition for denying virtual network peerings.