### PR TITLE
Update actions to use explicit versions

### DIFF
--- a/.github/workflows/initiative-definitions.yml
+++ b/.github/workflows/initiative-definitions.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Run Pester Tests
         run: Invoke-Pester -Path modules/policies/scripts/Test-Initiative.Tests.ps1 -CI
         shell: pwsh
@@ -42,9 +42,9 @@ jobs:
       name: Canary
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -100,9 +100,9 @@ jobs:
       name: Production
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
         with:
           # super-linter needs the full git history to get the
           # list of files that changed across commits

--- a/.github/workflows/management-groups.yml
+++ b/.github/workflows/management-groups.yml
@@ -36,9 +36,9 @@ jobs:
       name: Canary
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -78,9 +78,9 @@ jobs:
       name: Production
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/management.yml
+++ b/.github/workflows/management.yml
@@ -36,9 +36,9 @@ jobs:
       name: Canary
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -81,9 +81,9 @@ jobs:
       name: Production
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/policy-assignments.yml
+++ b/.github/workflows/policy-assignments.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Run Pester Tests
         run: Invoke-Pester -Path modules/policies/scripts/Test-Assignment.Tests.ps1 -CI
         shell: pwsh
@@ -51,9 +51,9 @@ jobs:
             folder: landing-zones/online
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -121,9 +121,9 @@ jobs:
             folder: landing-zones/online
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/policy-definitions.yml
+++ b/.github/workflows/policy-definitions.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Run Pester Tests
         run: Invoke-Pester -Path modules/policies/scripts/Test-Definition.Tests.ps1 -CI
         shell: pwsh
@@ -42,9 +42,9 @@ jobs:
       name: Canary
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -98,9 +98,9 @@ jobs:
       name: Production
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/policy-remediation.yml
+++ b/.github/workflows/policy-remediation.yml
@@ -25,9 +25,9 @@ jobs:
       name: Canary
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -48,9 +48,9 @@ jobs:
       name: Production
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.0
       - name: Login to Azure
-        uses: azure/login@v2
+        uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
This pull request includes updates to various GitHub Actions workflows to use more recent versions of the `actions/checkout` and `azure/login` actions. These changes ensure that we are using the latest features and security updates provided by these actions.

Updates to GitHub Actions workflows:

* [`.github/workflows/initiative-definitions.yml`](diffhunk://#diff-4d01597e5f1c95284c04f93190f12c90ec09a370660b8859d70d13fcca635a99L31-R31): Updated `actions/checkout` to `v4.2.0` and `azure/login` to `v2.2.0` in multiple jobs. [[1]](diffhunk://#diff-4d01597e5f1c95284c04f93190f12c90ec09a370660b8859d70d13fcca635a99L31-R31) [[2]](diffhunk://#diff-4d01597e5f1c95284c04f93190f12c90ec09a370660b8859d70d13fcca635a99L45-R47) [[3]](diffhunk://#diff-4d01597e5f1c95284c04f93190f12c90ec09a370660b8859d70d13fcca635a99L103-R105)
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L26-R26): Updated `actions/checkout` to `v4.2.0`.
* [`.github/workflows/management-groups.yml`](diffhunk://#diff-5a1e951570f38572638255c7c66bbf2536f477031378bd10c90fd8e1a9cad054L39-R41): Updated `actions/checkout` to `v4.2.0` and `azure/login` to `v2.2.0` in multiple jobs. [[1]](diffhunk://#diff-5a1e951570f38572638255c7c66bbf2536f477031378bd10c90fd8e1a9cad054L39-R41) [[2]](diffhunk://#diff-5a1e951570f38572638255c7c66bbf2536f477031378bd10c90fd8e1a9cad054L81-R83)
* [`.github/workflows/management.yml`](diffhunk://#diff-76bb5ad2f059f6d871eac0eb39a6b8388ec46b4a37cc2becc2641592e1831014L39-R41): Updated `actions/checkout` to `v4.2.0` and `azure/login` to `v2.2.0` in multiple jobs. [[1]](diffhunk://#diff-76bb5ad2f059f6d871eac0eb39a6b8388ec46b4a37cc2becc2641592e1831014L39-R41) [[2]](diffhunk://#diff-76bb5ad2f059f6d871eac0eb39a6b8388ec46b4a37cc2becc2641592e1831014L84-R86)
* [`.github/workflows/policy-assignments.yml`](diffhunk://#diff-4acd22007597323a5a6983c71e8dc5779d1155a9f470f2731f84e85d676d01c5L31-R31): Updated `actions/checkout` to `v4.2.0` and `azure/login` to `v2.2.0` in multiple jobs. [[1]](diffhunk://#diff-4acd22007597323a5a6983c71e8dc5779d1155a9f470f2731f84e85d676d01c5L31-R31) [[2]](diffhunk://#diff-4acd22007597323a5a6983c71e8dc5779d1155a9f470f2731f84e85d676d01c5L54-R56) [[3]](diffhunk://#diff-4acd22007597323a5a6983c71e8dc5779d1155a9f470f2731f84e85d676d01c5L124-R126)
* [`.github/workflows/policy-definitions.yml`](diffhunk://#diff-f69201b84986475b74328f4b740f1d1b430477241b6463012d036aed144938c0L31-R31): Updated `actions/checkout` to `v4.2.0` and `azure/login` to `v2.2.0` in multiple jobs. [[1]](diffhunk://#diff-f69201b84986475b74328f4b740f1d1b430477241b6463012d036aed144938c0L31-R31) [[2]](diffhunk://#diff-f69201b84986475b74328f4b740f1d1b430477241b6463012d036aed144938c0L45-R47) [[3]](diffhunk://#diff-f69201b84986475b74328f4b740f1d1b430477241b6463012d036aed144938c0L101-R103)
* [`.github/workflows/policy-remediation.yml`](diffhunk://#diff-99de63d8e2f26b85c03e6de8bb9ce8976a6b548cdebb5d4e272dbcec796ac1dbL28-R30): Updated `actions/checkout` to `v4.2.0` and `azure/login` to `v2.2.0` in multiple jobs. [[1]](diffhunk://#diff-99de63d8e2f26b85c03e6de8bb9ce8976a6b548cdebb5d4e272dbcec796ac1dbL28-R30) [[2]](diffhunk://#diff-99de63d8e2f26b85c03e6de8bb9ce8976a6b548cdebb5d4e272dbcec796ac1dbL51-R53)