### PR TITLE
Update onlineSubscriptionIds in prod management-groups.bicepparam

### DIFF
--- a/environments/canary/management-groups.bicepparam
+++ b/environments/canary/management-groups.bicepparam
@@ -6,4 +6,10 @@ param prefix = 'lz-canary'
 
 param managementSubscriptionId = '8228ddb9-d118-47b4-b4e7-1f1de7667d4d'
 
+param corpSubscriptionIds = []
+
 param onlineSubscriptionIds = []
+
+param sandboxSubscriptionIds = []
+
+param decommissionedSubscriptionIds = []

--- a/environments/prod/management-groups.bicepparam
+++ b/environments/prod/management-groups.bicepparam
@@ -6,4 +6,12 @@ param prefix = 'lz'
 
 param managementSubscriptionId = 'e678d35b-125e-41ad-ae35-c04dfd4162e5'
 
-param onlineSubscriptionIds = []
+param corpSubscriptionIds = []
+
+param onlineSubscriptionIds = [
+  'bd0c76c9-58a6-4c33-bda2-5dc48915446e'
+]
+
+param sandboxSubscriptionIds = []
+
+param decommissionedSubscriptionIds = []


### PR DESCRIPTION
This pull request includes updates to the `management-groups.bicepparam` files in both the `canary` and `prod` environments to add new subscription ID parameters and modify existing ones.

Updates to `management-groups.bicepparam` files:

* [`environments/canary/management-groups.bicepparam`](diffhunk://#diff-3b3b7ca88a01dec3dc896d575a9ab1e30691b5d970d4f966ff5c17adc3577fd3R9-R15): Added new parameters `corpSubscriptionIds`, `sandboxSubscriptionIds`, and `decommissionedSubscriptionIds` to the file.
* [`environments/prod/management-groups.bicepparam`](diffhunk://#diff-5c8357d888b7c6a992008c7c8b0b8e70ab2739b9ead98427c2065b36a9bf222fL9-R17): Added new parameters `corpSubscriptionIds`, `sandboxSubscriptionIds`, and `decommissionedSubscriptionIds`, and modified the `onlineSubscriptionIds` parameter to include specific subscription IDs.