### PR TITLE
Exemptions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
       "version": "latest"
     },
     "ghcr.io/devcontainers/features/powershell:1.5.0": {
-      "modules": "Az,Microsoft.Graph"
+      "modules": "Az,Microsoft.Graph,Pester"
     }
   },
   "postCreateCommand": "sudo chsh vscode -s \"$(which pwsh)\"",

--- a/.github/workflows/policy-assignments.yml
+++ b/.github/workflows/policy-assignments.yml
@@ -71,6 +71,14 @@ jobs:
             $folder = "${{ matrix.assignment.folder }}"
             ./modules/policies/scripts/Compare-Assignment.ps1 -ManagementGroupId $managementGroupId -Folder $folder
           azPSVersion: latest
+      - name: Compare exemptions
+        uses: azure/powershell@v2.0.0
+        with:
+          inlineScript: |
+            $managementGroupId = "${{ matrix.assignment.managementGroupId }}"
+            $folder = "${{ matrix.assignment.folder }}"
+            ./modules/policies/scripts/Compare-Exemption.ps1 -ManagementGroupId $managementGroupId -Folder $folder
+          azPSVersion: latest
       - name: Build Template
         run: |
           $folder = "${{ matrix.assignment.folder }}"
@@ -144,6 +152,15 @@ jobs:
             $managementGroupId = "${{ matrix.assignment.managementGroupId }}"
             $folder = "${{ matrix.assignment.folder }}"
             ./modules/policies/scripts/Compare-Assignment.ps1 -ManagementGroupId $managementGroupId -Folder $folder
+          azPSVersion: latest
+          errorActionPreference: ${{ github.ref == 'refs/heads/main' && 'Stop' || 'Continue' }}
+      - name: Compare exemptions
+        uses: azure/powershell@v2.0.0
+        with:
+          inlineScript: |
+            $managementGroupId = "${{ matrix.assignment.managementGroupId }}"
+            $folder = "${{ matrix.assignment.folder }}"
+            ./modules/policies/scripts/Compare-Exemption.ps1 -ManagementGroupId $managementGroupId -Folder $folder
           azPSVersion: latest
           errorActionPreference: ${{ github.ref == 'refs/heads/main' && 'Stop' || 'Continue' }}
       - name: Build Template

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,6 +37,7 @@
     "devcontainers",
     "eastasia",
     "eastus",
+    "Entra",
     "francecentral",
     "francesouth",
     "germanynorth",

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ The conceptual architecture is greatly simplified compared to the official one, 
 
 We do not want to manage network from a centralized perspective. All applications will be deployed as islands with no inter-network connectivity.
 
+We adopt a [Zero Trust](https://learn.microsoft.com/en-us/security/zero-trust/zero-trust-overview) approach where identity and encryption trumps and often replaced _Network Security_.
+
+We do not require nor encourage the use of [Azure Private Link](https://azure.microsoft.com/en-gb/products/private-link/).
+
+We allow most services to have _Public Network Access_: _Enabled_ because we rely on enforcing _Entra ID_ authentication and TLS encryption.
+
 ## Online Landing Zones
 
 These are the most important landing zones - all _newer_ applications should be deployed here - even if data resides on-premises.

--- a/modules/policies/README.md
+++ b/modules/policies/README.md
@@ -1,3 +1,3 @@
 # Policies Module
 
-This module deploys the policy definitions, initiatives, and assignments.
+This module deploys the policy definitions, initiatives, and assignments including exemptions.

--- a/modules/policies/assignments/landing-zones/online-onboarding/cloud-security-benchmark.bicep
+++ b/modules/policies/assignments/landing-zones/online-onboarding/cloud-security-benchmark.bicep
@@ -63,6 +63,21 @@ module Cloud_Security_Benchmark '../../../../shared/policy-assignment.bicep' = {
       privateEndpointShouldBeEnabledForPostgresqlServersMonitoringEffect: {
         value: 'Disabled'
       }
+      publicNetworkAccessOnAzureSQLDatabaseShouldBeDisabledMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForCognitiveServicesAccountsMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForMariaDbServersMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForMySqlServersMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForPostgreSqlServersMonitoringEffect: {
+        value: 'Disabled'
+      }
       storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect: {
         value: 'Disabled'
       }

--- a/modules/policies/assignments/landing-zones/online-onboarding/cloud-security-benchmark.bicep
+++ b/modules/policies/assignments/landing-zones/online-onboarding/cloud-security-benchmark.bicep
@@ -87,3 +87,27 @@ module Cloud_Security_Benchmark '../../../../shared/policy-assignment.bicep' = {
     }
   }
 }
+
+module Cloud_Security_Benchmark_Exemption '../../../../shared/policy-exemption.bicep' = {
+  name: 'cloud-security-benchmark-exemption'
+  dependsOn: [
+    Cloud_Security_Benchmark
+  ]
+  params: {
+    displayName: 'Exemption for cloud security benchmark'
+    description: 'We allow public network access and do not enforce the use of private link as all services will have Entra ID authentication and TLS encryption enforced instead.'
+    exemptionCategory: 'Mitigated'
+    policyExemptionName: 'cloud-security-benchmark-exemption'
+    policyAssignmentName: 'cloud-security-benchmark'
+    policyDefinitionReferenceIds: [
+      'azureSQLManagedInstancesShouldDisablePublicNetworkAccess'
+      'azureCosmosDBShouldDisablePublicNetworkAccess'
+      'aPIManagementServiceShouldDisableServiceConfigurationEndpoints'
+      'azureDatabricksWorkspacesShouldDisablePublicNetworkAccess'
+      'azureMachineLearningWorkspacesShouldDisablePublicNetworkAccess'
+      'cosmosDBAaccountsShouldUsePrivateLink'
+      'azureAIServicesResourcesShouldUseAzurePrivateLinkMonitoring'
+      'azureDatabricksWorkspacesShouldUsePrivateLink'
+    ]
+  }
+}

--- a/modules/policies/assignments/landing-zones/online/cloud-security-benchmark.bicep
+++ b/modules/policies/assignments/landing-zones/online/cloud-security-benchmark.bicep
@@ -63,6 +63,21 @@ module Cloud_Security_Benchmark '../../../../shared/policy-assignment.bicep' = {
       privateEndpointShouldBeEnabledForPostgresqlServersMonitoringEffect: {
         value: 'Disabled'
       }
+      publicNetworkAccessOnAzureSQLDatabaseShouldBeDisabledMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForCognitiveServicesAccountsMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForMariaDbServersMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForMySqlServersMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForPostgreSqlServersMonitoringEffect: {
+        value: 'Disabled'
+      }
       storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect: {
         value: 'Disabled'
       }

--- a/modules/policies/assignments/landing-zones/online/cloud-security-benchmark.bicep
+++ b/modules/policies/assignments/landing-zones/online/cloud-security-benchmark.bicep
@@ -87,3 +87,27 @@ module Cloud_Security_Benchmark '../../../../shared/policy-assignment.bicep' = {
     }
   }
 }
+
+module Cloud_Security_Benchmark_Exemption '../../../../shared/policy-exemption.bicep' = {
+  name: 'cloud-security-benchmark-exemption'
+  dependsOn: [
+    Cloud_Security_Benchmark
+  ]
+  params: {
+    displayName: 'Exemption for cloud security benchmark'
+    description: 'We allow public network access and do not enforce the use of private link as all services will have Entra ID authentication and TLS encryption enforced instead.'
+    exemptionCategory: 'Mitigated'
+    policyExemptionName: 'cloud-security-benchmark-exemption'
+    policyAssignmentName: 'cloud-security-benchmark'
+    policyDefinitionReferenceIds: [
+      'azureSQLManagedInstancesShouldDisablePublicNetworkAccess'
+      'azureCosmosDBShouldDisablePublicNetworkAccess'
+      'aPIManagementServiceShouldDisableServiceConfigurationEndpoints'
+      'azureDatabricksWorkspacesShouldDisablePublicNetworkAccess'
+      'azureMachineLearningWorkspacesShouldDisablePublicNetworkAccess'
+      'cosmosDBAaccountsShouldUsePrivateLink'
+      'azureAIServicesResourcesShouldUseAzurePrivateLinkMonitoring'
+      'azureDatabricksWorkspacesShouldUsePrivateLink'
+    ]
+  }
+}

--- a/modules/policies/assignments/platform/cloud-security-benchmark.bicep
+++ b/modules/policies/assignments/platform/cloud-security-benchmark.bicep
@@ -87,3 +87,27 @@ module Cloud_Security_Benchmark '../../../shared/policy-assignment.bicep' = {
     }
   }
 }
+
+module Cloud_Security_Benchmark_Exemption '../../../shared/policy-exemption.bicep' = {
+  name: 'cloud-security-benchmark-exemption'
+  dependsOn: [
+    Cloud_Security_Benchmark
+  ]
+  params: {
+    displayName: 'Exemption for cloud security benchmark'
+    description: 'We allow public network access and do not enforce the use of private link as all services will have Entra ID authentication and TLS encryption enforced instead.'
+    exemptionCategory: 'Mitigated'
+    policyExemptionName: 'cloud-security-benchmark-exemption'
+    policyAssignmentName: 'cloud-security-benchmark'
+    policyDefinitionReferenceIds: [
+      'azureSQLManagedInstancesShouldDisablePublicNetworkAccess'
+      'azureCosmosDBShouldDisablePublicNetworkAccess'
+      'aPIManagementServiceShouldDisableServiceConfigurationEndpoints'
+      'azureDatabricksWorkspacesShouldDisablePublicNetworkAccess'
+      'azureMachineLearningWorkspacesShouldDisablePublicNetworkAccess'
+      'cosmosDBAaccountsShouldUsePrivateLink'
+      'azureAIServicesResourcesShouldUseAzurePrivateLinkMonitoring'
+      'azureDatabricksWorkspacesShouldUsePrivateLink'
+    ]
+  }
+}

--- a/modules/policies/assignments/platform/cloud-security-benchmark.bicep
+++ b/modules/policies/assignments/platform/cloud-security-benchmark.bicep
@@ -63,6 +63,21 @@ module Cloud_Security_Benchmark '../../../shared/policy-assignment.bicep' = {
       privateEndpointShouldBeEnabledForPostgresqlServersMonitoringEffect: {
         value: 'Disabled'
       }
+      publicNetworkAccessOnAzureSQLDatabaseShouldBeDisabledMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForCognitiveServicesAccountsMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForMariaDbServersMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForMySqlServersMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForPostgreSqlServersMonitoringEffect: {
+        value: 'Disabled'
+      }
       storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect: {
         value: 'Disabled'
       }

--- a/modules/policies/assignments/sandbox/cloud-security-benchmark.bicep
+++ b/modules/policies/assignments/sandbox/cloud-security-benchmark.bicep
@@ -87,3 +87,27 @@ module Cloud_Security_Benchmark '../../../shared/policy-assignment.bicep' = {
     }
   }
 }
+
+module Cloud_Security_Benchmark_Exemption '../../../shared/policy-exemption.bicep' = {
+  name: 'cloud-security-benchmark-exemption'
+  dependsOn: [
+    Cloud_Security_Benchmark
+  ]
+  params: {
+    displayName: 'Exemption for cloud security benchmark'
+    description: 'We allow public network access and do not enforce the use of private link as all services will have Entra ID authentication and TLS encryption enforced instead.'
+    exemptionCategory: 'Mitigated'
+    policyExemptionName: 'cloud-security-benchmark-exemption'
+    policyAssignmentName: 'cloud-security-benchmark'
+    policyDefinitionReferenceIds: [
+      'azureSQLManagedInstancesShouldDisablePublicNetworkAccess'
+      'azureCosmosDBShouldDisablePublicNetworkAccess'
+      'aPIManagementServiceShouldDisableServiceConfigurationEndpoints'
+      'azureDatabricksWorkspacesShouldDisablePublicNetworkAccess'
+      'azureMachineLearningWorkspacesShouldDisablePublicNetworkAccess'
+      'cosmosDBAaccountsShouldUsePrivateLink'
+      'azureAIServicesResourcesShouldUseAzurePrivateLinkMonitoring'
+      'azureDatabricksWorkspacesShouldUsePrivateLink'
+    ]
+  }
+}

--- a/modules/policies/assignments/sandbox/cloud-security-benchmark.bicep
+++ b/modules/policies/assignments/sandbox/cloud-security-benchmark.bicep
@@ -63,6 +63,21 @@ module Cloud_Security_Benchmark '../../../shared/policy-assignment.bicep' = {
       privateEndpointShouldBeEnabledForPostgresqlServersMonitoringEffect: {
         value: 'Disabled'
       }
+      publicNetworkAccessOnAzureSQLDatabaseShouldBeDisabledMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForCognitiveServicesAccountsMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForMariaDbServersMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForMySqlServersMonitoringEffect: {
+        value: 'Disabled'
+      }
+      publicNetworkAccessShouldBeDisabledForPostgreSqlServersMonitoringEffect: {
+        value: 'Disabled'
+      }
       storageAccountShouldUseAPrivateLinkConnectionMonitoringEffect: {
         value: 'Disabled'
       }

--- a/modules/policies/scripts/Compare-Exemption.ps1
+++ b/modules/policies/scripts/Compare-Exemption.ps1
@@ -1,0 +1,45 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [String]
+    $Folder,
+
+    [Parameter(Mandatory = $true)]
+    [String]
+    [ValidateNotNullOrEmpty()]
+    $ManagementGroupId
+)
+
+function Write-Compare($Object, $SideIndicator, $Label, $Prefix, $ErrorMessage) {
+    $output = $Object | Where-Object SideIndicator -eq $SideIndicator | ForEach-Object { "$Prefix $($PSItem.InputObject)" }
+
+    if ($output) {
+        Write-Output $Label
+        Write-Output $output
+        Write-Output ""
+
+        if ($ErrorMessage) {
+            Write-Error $ErrorMessage
+        }
+    }
+}
+
+$assignmentsFolder = Join-Path -Path $PSScriptRoot -ChildPath "../assignments/$Folder"
+
+$source = Get-ChildItem -Path $assignmentsFolder -Filter "*.bicep" | ForEach-Object {
+    $name = $PSItem | Get-Content -Raw | Select-String -Pattern "policyExemptionName: '(.+)'"
+    if ($name.Matches.Groups) {
+        $name.Matches.Groups[1].Value
+    }
+}
+
+$cloud = Get-AzPolicyExemption -Scope "/providers/Microsoft.Management/managementGroups/$ManagementGroupId" |
+Where-Object Id -Match "/providers/Microsoft.Management/managementGroups/$ManagementGroupId/providers/Microsoft.Authorization/policyExemptions" |
+Select-Object -ExpandProperty Name
+
+$compare = Compare-Object -ReferenceObject ($cloud ?? @()) -DifferenceObject ($source ?? @()) -IncludeEqual
+
+Write-Compare -Object $compare -SideIndicator "=>" -Label "Exemptions to be created:" -Prefix "+"
+Write-Compare -Object $compare -SideIndicator "==" -Label "Exemptions to be updated:" -Prefix "*"
+Write-Compare -Object $compare -SideIndicator "<=" -Label "Exemptions to be deleted:" -Prefix "-" -ErrorMessage "Delete detected. Manual intervention required."

--- a/modules/shared/README.md
+++ b/modules/shared/README.md
@@ -1,3 +1,5 @@
 # Shared Module
 
 This module contains bicep modules used by other modules.
+
+The module is not to be used as an organizational _Shared Template Library_ and will only contain modules which are in use in this repository.

--- a/modules/shared/policy-exemption.bicep
+++ b/modules/shared/policy-exemption.bicep
@@ -1,0 +1,27 @@
+targetScope = 'managementGroup'
+
+param policyExemptionName string
+param displayName string = ''
+param description string = ''
+@allowed([
+  'Mitigated'
+  'Waiver'
+])
+param exemptionCategory string
+param expiresOn string = ''
+param policyAssignmentName string
+param policyDefinitionReferenceIds array = []
+param resourceSelectors array = []
+
+resource policyExemption 'Microsoft.Authorization/policyExemptions@2022-07-01-preview' = {
+  name: policyExemptionName
+  properties: {
+    displayName: displayName
+    description: description
+    exemptionCategory: exemptionCategory
+    expiresOn: expiresOn
+    policyAssignmentId: managementGroupResourceId('Microsoft.Authorization/policyAssignments', policyAssignmentName)
+    policyDefinitionReferenceIds: policyDefinitionReferenceIds
+    resourceSelectors: resourceSelectors
+  }
+}


### PR DESCRIPTION
This pull request introduces several significant updates, focusing on policy management, security benchmarks, and enhancing the documentation. The most important changes include adding new modules and exemptions for policy assignments, updating workflow scripts, and modifying documentation to reflect new security practices.

### Policy Management Enhancements:
* Added `Compare-Exemption.ps1` script to compare policy exemptions and identify changes needed for creation, update, or deletion of exemptions.
* Included new policy exemption modules in various `cloud-security-benchmark.bicep` files to allow public network access while enforcing Entra ID authentication and TLS encryption. [[1]](diffhunk://#diff-8964ab713b159c3ad84fd39f388c615d464681b5c1c29591755f731fe2bf1326R90-R113) [[2]](diffhunk://#diff-532a8c6cd0dbd09d771eeeddbc7d3a1fdc3daf5a0c143d973275375bf571fc0fR90-R113)

### Workflow Updates:
* Updated `.github/workflows/policy-assignments.yml` to include steps for comparing exemptions using the new `Compare-Exemption.ps1` script. [[1]](diffhunk://#diff-4acd22007597323a5a6983c71e8dc5779d1155a9f470f2731f84e85d676d01c5R74-R81) [[2]](diffhunk://#diff-4acd22007597323a5a6983c71e8dc5779d1155a9f470f2731f84e85d676d01c5R157-R165)

### Security Benchmarks:
* Added multiple policy effects to allow public network access for various services in `cloud-security-benchmark.bicep` files across different environments. [[1]](diffhunk://#diff-8964ab713b159c3ad84fd39f388c615d464681b5c1c29591755f731fe2bf1326R66-R80) [[2]](diffhunk://#diff-532a8c6cd0dbd09d771eeeddbc7d3a1fdc3daf5a0c143d973275375bf571fc0fR66-R80)

### Documentation Improvements:
* Updated `README.md` to include the adoption of a Zero Trust approach and the allowance of public network access with enforced Entra ID authentication and TLS encryption.
* Enhanced `modules/policies/README.md` and `modules/shared/README.md` to reflect the inclusion of exemptions and clarify the usage of shared modules. [[1]](diffhunk://#diff-255ac20d9816cfd59831f9af0c2e570dffec0cedabf73e90f173935c6d6753beL3-R3) [[2]](diffhunk://#diff-f6c4dc672c046ef9e7ee63a1706a73d2d57ae875e730a67398c1218f9b9cbae9R4-R5)