### PR TITLE
Update cloud-security-benchmark.bicep

### DIFF
--- a/modules/policies/assignments/landing-zones/corp/cloud-security-benchmark.bicep
+++ b/modules/policies/assignments/landing-zones/corp/cloud-security-benchmark.bicep
@@ -11,6 +11,10 @@ module Cloud_Security_Benchmark '../../../../shared/policy-assignment.bicep' = {
       'Microsoft.Authorization/policySetDefinitions',
       '1f3afdf9-d0c9-4c3d-847f-89da613e70a8'
     )
-    parameters: {}
+    parameters: {
+      networkWatcherShouldBeEnabledResourceGroupName: {
+        value: 'Management'
+      }
+    }
   }
 }


### PR DESCRIPTION
This pull request includes a change to the `cloud-security-benchmark.bicep` file to enhance the configuration of the policy assignment by adding parameters for the network watcher resource group.

Configuration enhancement:

* [`modules/policies/assignments/landing-zones/corp/cloud-security-benchmark.bicep`](diffhunk://#diff-e7748e31ff025ef1f76c68c45aa81615c38ffdb2b137b0196eb24a620dc17e76L14-R18): Added `networkWatcherShouldBeEnabledResourceGroupName` parameter with a value of 'Management' to the policy assignment to specify the resource group for the network watcher.