### PR TITLE
Add onboarding management groups to policy assignment and remediation…

### DIFF
--- a/.github/workflows/policy-assignments.yml
+++ b/.github/workflows/policy-assignments.yml
@@ -51,6 +51,8 @@ jobs:
             folder: landing-zones/corp
           - managementGroupId: lz-canary-landing-zones-online
             folder: landing-zones/online
+          - managementGroupId: lz-canary-landing-zones-online-onboarding
+            folder: landing-zones/online-onboarding
           - managementGroupId: lz-canary-sandbox
             folder: sandbox
     steps:
@@ -133,6 +135,8 @@ jobs:
             folder: landing-zones/corp
           - managementGroupId: lz-landing-zones-online
             folder: landing-zones/online
+          - managementGroupId: lz-landing-zones-online-onboarding
+            folder: landing-zones/online-onboarding
           - managementGroupId: lz-sandbox
             folder: sandbox
     steps:

--- a/.github/workflows/policy-remediation.yml
+++ b/.github/workflows/policy-remediation.yml
@@ -36,6 +36,7 @@ jobs:
           - managementGroupId: lz-canary-platform
           - managementGroupId: lz-canary-landing-zones-corp
           - managementGroupId: lz-canary-landing-zones-online
+          - managementGroupId: lz-canary-landing-zones-online-onboarding
           - managementGroupId: lz-canary-sandbox
     steps:
       - name: Checkout
@@ -67,6 +68,7 @@ jobs:
           - managementGroupId: lz-platform
           - managementGroupId: lz-landing-zones-corp
           - managementGroupId: lz-landing-zones-online
+          - managementGroupId: lz-landing-zones-online-onboarding
           - managementGroupId: lz-sandbox
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request updates the `.github/workflows/policy-assignments.yml` and `.github/workflows/policy-remediation.yml` files to include new management groups for onboarding. The most important changes are the addition of the `lz-canary-landing-zones-online-onboarding` and `lz-landing-zones-online-onboarding` management groups.

### Updates to policy assignments and remediation:

* [`.github/workflows/policy-assignments.yml`](diffhunk://#diff-4acd22007597323a5a6983c71e8dc5779d1155a9f470f2731f84e85d676d01c5R54-R55): Added `lz-canary-landing-zones-online-onboarding` and `lz-landing-zones-online-onboarding` management groups to the list of management groups. [[1]](diffhunk://#diff-4acd22007597323a5a6983c71e8dc5779d1155a9f470f2731f84e85d676d01c5R54-R55) [[2]](diffhunk://#diff-4acd22007597323a5a6983c71e8dc5779d1155a9f470f2731f84e85d676d01c5R138-R139)
* [`.github/workflows/policy-remediation.yml`](diffhunk://#diff-99de63d8e2f26b85c03e6de8bb9ce8976a6b548cdebb5d4e272dbcec796ac1dbR39): Added `lz-canary-landing-zones-online-onboarding` and `lz-landing-zones-online-onboarding` management groups to the list of management groups. [[1]](diffhunk://#diff-99de63d8e2f26b85c03e6de8bb9ce8976a6b548cdebb5d4e272dbcec796ac1dbR39) [[2]](diffhunk://#diff-99de63d8e2f26b85c03e6de8bb9ce8976a6b548cdebb5d4e272dbcec796ac1dbR71)… workflows