### PR TITLE
Fix parent reference in online onboarding subscription resource

### DIFF
--- a/modules/management-groups/main.bicep
+++ b/modules/management-groups/main.bicep
@@ -155,7 +155,7 @@ resource onlineOnboarding 'Microsoft.Management/managementGroups@2023-04-01' = {
 resource onlineOnboardingSubscription 'Microsoft.Management/managementGroups/subscriptions@2023-04-01' = [
   for subscriptionId in onlineOnboardingSubscriptionIds: {
     name: subscriptionId
-    parent: online
+    parent: onlineOnboarding
   }
 ]
 


### PR DESCRIPTION
This pull request includes a change to the `modules/management-groups/main.bicep` file, specifically to the `onlineOnboardingSubscription` resource. The change updates the parent property of the resource.

* [`modules/management-groups/main.bicep`](diffhunk://#diff-3b4e68860f25a1f0346bd09e845840c0288aa928247e1f3d2a051bd6c77c28e1L158-R158): Changed the `parent` property of the `onlineOnboardingSubscription` resource from `online` to `onlineOnboarding`.